### PR TITLE
chore: bump lean-toolchain to v4.2.0-rc4

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.2.0-rc2
+leanprover/lean4:v4.2.0-rc4


### PR DESCRIPTION
Fixes a potential data loss bug. All projects should update their toolchain as soon as possible.

Please see https://github.com/leanprover/lean4/releases/tag/v4.2.0-rc4 and the [zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Potential.20data.20loss.20from.20.60lake.20clean.60.20with.204.2E2.2E0-rc2.2F3/near/397875701) for more information.